### PR TITLE
Do not append filenames with '-min' by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Global options:
   -h, --help              Output usage information. (will ignore any other arguments)
   -v, --version           Output package version. (will ignore any other arguments)
   -m, --minify-hex                Will minify the hexadecimal color values. (default = false)
-  -s, --suffix            The string of the suffix file. (default = "-min")
+  -s, --suffix            Append a suffix string to the minified filename
   -o, --output            The new output file (will ignore "--suffix" argument)
   -d, --dir               Will recursively look for HTML/CSS/JSON files inside a directory and will minify every one (will ignore "--output" argument)
 

--- a/src/cli/argumentParser.ts
+++ b/src/cli/argumentParser.ts
@@ -28,7 +28,7 @@ export function parseArgumentsIntoOptions(rawArgs: string[]): ArgumentsOptions {
         help: args['--help'] || false,
         version: args['--version'] || false,
         willMinifyHex: args['--minify-hex'] || false,
-        suffix: args['--suffix'] || '-min',
+        suffix: args['--suffix'] || '',
         output: args['--output'] || null,
         directory: args['--dir'] || null,
         file: args._[0],

--- a/tests/argumentParser.test.ts
+++ b/tests/argumentParser.test.ts
@@ -13,7 +13,7 @@ test('parseArgumentsIntoOptions help argument works', () => {
         "file": undefined,
         "help": true,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });
@@ -22,7 +22,7 @@ test('parseArgumentsIntoOptions help argument works', () => {
         "file": undefined,
         "help": true,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });
@@ -38,7 +38,7 @@ test('parseArgumentsIntoOptions version argument works', () => {
         "file": undefined,
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": true,
         "willMinifyHex": false
     });
@@ -47,7 +47,7 @@ test('parseArgumentsIntoOptions version argument works', () => {
         "file": undefined,
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": true,
         "willMinifyHex": false
     });
@@ -63,7 +63,7 @@ test('parseArgumentsIntoOptions minify hex (colors) argument works', () => {
         "file": undefined,
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": true
     });
@@ -72,7 +72,7 @@ test('parseArgumentsIntoOptions minify hex (colors) argument works', () => {
         "file": undefined,
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": true
     });
@@ -89,7 +89,7 @@ test('parseArgumentsIntoOptions suffix argument works', () => {
         "file": undefined,
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });
@@ -123,7 +123,7 @@ test('parseArgumentsIntoOptions output argument works', () => {
         "file": undefined,
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });
@@ -132,7 +132,7 @@ test('parseArgumentsIntoOptions output argument works', () => {
         "file": undefined,
         "help": false,
         "output": '/myPath',
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });
@@ -141,7 +141,7 @@ test('parseArgumentsIntoOptions output argument works', () => {
         "file": undefined,
         "help": false,
         "output": '/myPath/file.css',
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });
@@ -157,7 +157,7 @@ test('parseArgumentsIntoOptions dir argument works', () => {
         "file": undefined,
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });
@@ -166,7 +166,7 @@ test('parseArgumentsIntoOptions dir argument works', () => {
         "file": undefined,
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });
@@ -175,7 +175,7 @@ test('parseArgumentsIntoOptions dir argument works', () => {
         "file": undefined,
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });
@@ -190,7 +190,7 @@ test('parseArgumentsIntoOptions file argument works', () => {
         "file": undefined,
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });
@@ -199,7 +199,7 @@ test('parseArgumentsIntoOptions file argument works', () => {
         "file": 'myFile.css',
         "help": false,
         "output": null,
-        "suffix": "-min",
+        "suffix": "",
         "version": false,
         "willMinifyHex": false
     });


### PR DESCRIPTION
A suffix ("-min") is appended to filenames by default, even if an empty string is passed (-s ""). Therefore, output files cannot have an empty suffix.

This PR makes the suffix argument an 'opt-in' feature, by defaulting it to a blank string (""), instead of "-min".